### PR TITLE
Fix for episode titles breaking paths

### DIFF
--- a/bin/ruby-tapas-downloader
+++ b/bin/ruby-tapas-downloader
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-if ARGV.count != 3
+if ARGV.count < 3
   abort <<-USAGE
 Usage:
-$ ruby-tapas-downloader <email> <password> <download-path>
+$ ruby-tapas-downloader <email> <password> <download-path> <no_ssl_verify>
   USAGE
 end
 

--- a/lib/ruby_tapas_downloader/cli.rb
+++ b/lib/ruby_tapas_downloader/cli.rb
@@ -5,10 +5,13 @@ class RubyTapasDownloader::CLI
   # @param email [String] the e-mail for the user.
   # @param password [String] the password for the user.
   # @param download_path [String] the path in which the download is performed.
-  def initialize email, password, download_path
+  # @param no_ssl_verify [Boolean] disable SSL certificate verification
+  #def initialize email, password, download_path
+  def initialize email, password, download_path, no_ssl_verify = false
     @email         = email
     @password      = password
     @download_path = download_path
+    @no_ssl_verify = no_ssl_verify
   end
 
   # Perform complete download procedure.
@@ -24,6 +27,7 @@ class RubyTapasDownloader::CLI
 
   def create_agent
     @agent = Mechanize.new
+    @agent.verify_mode = OpenSSL::SSL::VERIFY_NONE if @no_ssl_verify
   end
 
   def login

--- a/lib/ruby_tapas_downloader/downloadables/episode.rb
+++ b/lib/ruby_tapas_downloader/downloadables/episode.rb
@@ -22,9 +22,20 @@ class RubyTapasDownloader::Downloadables::Episode <
   #
   # @return [String] the sanitized title.
   def sanitized_title
-    @sanitized_title ||= title.downcase.gsub(/[^\w<>#?!$]+/, '-')
-  end
+  #  @sanitized_title ||= title.downcase.gsub(/[^\w<>#?!$]+/, '-')
 
+    sanitize_list = {'default' => {:pattern => /[^\w<>#?!$]+/, :replace => '-'},
+                     '<<' => {:pattern => /[<<]+/},
+                     '?' => {:pattern => /[?]+/},
+                     '#' => {:pattern => /[#]+/}}
+
+      title_to_sanitize = title.downcase
+      sanitize_list.each do |key, value|
+      title_to_sanitize = title_to_sanitize.gsub(value[:pattern], value[:replace] || '')
+    end
+
+    @sanitized_title ||= title_to_sanitize
+  end
 
   # Download the Episode.
   #


### PR DESCRIPTION
Very new to Ruby (3 weeks) so there is probably better ways to do this. 
1. Add option to disable SSL certificate verification.
2. Tried to fix edge cases where the episode title would contain invalid characters (testing on Windows) for target paths.
