### PR TITLE
Fail gracefully when `download_path` isn't valid

### DIFF
--- a/lib/ruby-tapas-downloader.rb
+++ b/lib/ruby-tapas-downloader.rb
@@ -23,6 +23,7 @@ end
 require 'bundler/setup'
 require 'mechanize'
 
+require_relative 'ruby_tapas_downloader/exceptions'
 require_relative 'ruby_tapas_downloader/downloadables'
 
 require_relative 'ruby_tapas_downloader/extractors'

--- a/lib/ruby_tapas_downloader/downloadable.rb
+++ b/lib/ruby_tapas_downloader/downloadable.rb
@@ -1,7 +1,7 @@
 # The contract for Downloadables.
 class RubyTapasDownloader::Downloadable
   # Should be implemented by children.
-  def download basepath, agent
+  def download(_basepath, _agent)
     fail NotImplementedError
   end
 end

--- a/lib/ruby_tapas_downloader/downloadables/catalog.rb
+++ b/lib/ruby_tapas_downloader/downloadables/catalog.rb
@@ -1,34 +1,43 @@
-# Catalog is the set of all Ruby Tapas Episodes.
-class RubyTapasDownloader::Downloadables::Catalog <
-                                              RubyTapasDownloader::Downloadable
+module RubyTapasDownloader
+  # Catalog is the set of all Ruby Tapas Episodes.
+  class Downloadables::Catalog < Downloadable
+    # @return [Set<RubyTapasDownloader::Downloadables::Episode>] the Episodes.
+    attr_reader :episodes
 
-  # @return [Set<RubyTapasDownloader::Downloadables::Episode>] the Episodes.
-  attr_reader :episodes
+    def initialize(episodes)
+      @episodes = episodes
+    end
 
-  def initialize(episodes)
-    @episodes = episodes
-  end
+    # Download the Catalog.
+    #
+    # @param basepath [String] the path to place download.
+    # @param agent [Mechanize] the Mechanize agent.
+    def download(basepath, agent)
+      RubyTapasDownloader.logger.info 'Starting download of catalog in ' \
+                                      "`#{ basepath }'..."
+      unless nice_download_path? basepath
+        fail Exceptions::BadDownloadPath, basepath
+      end
 
-  # Download the Catalog.
-  #
-  # @param basepath [String] the path to place download.
-  # @param agent [Mechanize] the Mechanize agent.
-  def download(basepath, agent)
-    RubyTapasDownloader.logger.info 'Starting download of catalog in ' \
-                                    "`#{ basepath }'..."
-    FileUtils.mkdir_p basepath
-    episodes.each { |episode| episode.download basepath, agent }
-  end
+      episodes.each { |episode| episode.download basepath, agent }
+    end
 
-  def ==(other)
-    episodes == other.episodes
-  end
+    def ==(other)
+      episodes == other.episodes
+    end
 
-  def eql?(other)
-    episodes.eql? other.episodes
-  end
+    def eql?(other)
+      episodes.eql? other.episodes
+    end
 
-  def hash
-    episodes.hash
+    def hash
+      episodes.hash
+    end
+
+    private
+
+    def nice_download_path?(basepath)
+      File.directory?(basepath)
+    end
   end
 end

--- a/lib/ruby_tapas_downloader/exceptions.rb
+++ b/lib/ruby_tapas_downloader/exceptions.rb
@@ -1,0 +1,5 @@
+# Namespace module for Exceptions.
+module RubyTapasDownloader::Exceptions
+end
+
+require_relative 'exceptions/bad_download_path'

--- a/lib/ruby_tapas_downloader/exceptions/bad_download_path.rb
+++ b/lib/ruby_tapas_downloader/exceptions/bad_download_path.rb
@@ -1,0 +1,7 @@
+# Bad download path exception
+class RubyTapasDownloader::Exceptions::BadDownloadPath < StandardError
+  def initialize(download_path)
+    super 'The following path isn\'t valid to place the downloaded Ruby Tapas'\
+          " episodes: `<#{download_path}>"
+  end
+end

--- a/spec/ruby_tapas_downloader/downloadable_spec.rb
+++ b/spec/ruby_tapas_downloader/downloadable_spec.rb
@@ -4,8 +4,8 @@ describe RubyTapasDownloader::Downloadable do
   let(:downloadable_class) { Class.new RubyTapasDownloader::Downloadable }
 
   describe 'contract' do
-    let(:base_path) { }
-    let(:agent) { }
+    let(:base_path) {}
+    let(:agent) {}
 
     specify('#download') do
       expect { downloadable.download base_path, agent }

--- a/spec/ruby_tapas_downloader/downloadables/catalog_spec.rb
+++ b/spec/ruby_tapas_downloader/downloadables/catalog_spec.rb
@@ -12,23 +12,37 @@ describe RubyTapasDownloader::Downloadables::Catalog do
   end
 
   describe '#download' do
-    let(:basepath)     { '/tmp/ruby-tapas' }
+    subject(:download_catalod) { catalog.download basepath, agent }
+
+    let(:basepath)     { Dir.pwd }
     let(:agent)        { double }
 
     before { allow(FileUtils).to receive(:mkdir_p) }
-
-    it 'creates folder for catalog' do
-      expect(FileUtils).to receive(:mkdir_p).with(basepath)
-
-      catalog.download basepath, agent
-    end
 
     it 'calls #download on each episode' do
       episodes.each do |episode|
         expect(episode).to receive(:download).with(basepath, agent)
       end
 
-      catalog.download basepath, agent
+      download_catalod
+    end
+
+    context 'with invalid download_path' do
+      let(:basepath) { '/tmp/some-crazy-folder/you-dont-have-this' }
+
+      specify do
+        expect { download_catalod }.to raise_error(
+                              RubyTapasDownloader::Exceptions::BadDownloadPath)
+      end
+    end
+
+    context 'with a file instead of a directory' do
+      let(:basepath) { File.absolute_path(__FILE__) }
+
+      specify do
+        expect { download_catalod }.to raise_error(
+                              RubyTapasDownloader::Exceptions::BadDownloadPath)
+      end
     end
   end
 


### PR DESCRIPTION
In #5 a user was misled by the parameter name and filled it wrong.

A proper error message is required for this case:

```
The following path isn't valid to place the downloaded Ruby Tapas episodes: `<given-download-path>'
```
