### PR TITLE
Update outdated description for download command

### DIFF
--- a/lib/ruby_tapas_downloader/cli.rb
+++ b/lib/ruby_tapas_downloader/cli.rb
@@ -46,7 +46,7 @@ To download you need to be authenticated, you have tree options:
   end
 
   # Configure user preferences
-  desc 'configure -e foo@bar.com -p 123 -l .', 'Configure user preferences'
+  desc 'configure -e foo@bar.com -p 123 -d .', 'Configure user preferences'
   option :email,         required: true, aliases: '-e'
   option :password,      required: true, aliases: '-p'
   option :download_path, required: true, aliases: '-d'


### PR DESCRIPTION
Update the description of the configure command to display the correct alias -d for the --download-path option. This was forgotten when the alias changed from -l to -d in commit 15016c79ad017a92a5c08fededa5854471026ded.

(I would also vote for using the more explicit --email --password and --download-path options in the description but did not include them in the PR.)
