### PR TITLE
Progress bar using Mechanize-Progressbar gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'mechanize-progressbar', :git => 'https://github.com/mawaldne/Mechanize-ProgressBar'

--- a/lib/ruby-tapas-downloader.rb
+++ b/lib/ruby-tapas-downloader.rb
@@ -22,6 +22,8 @@ end
 
 require 'bundler/setup'
 require 'mechanize'
+require 'mechanize/progressbar'
+
 
 require_relative 'ruby_tapas_downloader/exceptions'
 require_relative 'ruby_tapas_downloader/downloadables'

--- a/lib/ruby_tapas_downloader/cli.rb
+++ b/lib/ruby_tapas_downloader/cli.rb
@@ -79,6 +79,7 @@ To download, you need to be authenticated. You have three options:
 
   def create_agent
     @agent = Mechanize.new
+    @agent.pluggable_parser.default = Mechanize::Download
   end
 
   def set_log_level

--- a/lib/ruby_tapas_downloader/downloadables/file.rb
+++ b/lib/ruby_tapas_downloader/downloadables/file.rb
@@ -26,7 +26,9 @@ class RubyTapasDownloader::Downloadables::File <
     else
       RubyTapasDownloader.logger.info "Starting download of file `#{ name }' " \
         "in `#{ file_path }'..."
-      agent.download link, file_path
+      agent.progressbar do
+        agent.download link, file_path
+      end
     end
   end
 


### PR DESCRIPTION
Adds a progress bar to the downloads!
![screenshot 2014-12-20 20 06 16](https://cloud.githubusercontent.com/assets/40419/5517058/06fd6f3a-8884-11e4-8524-2a88e2e9a184.png)

One problem with this commit is its using my github version of Mechanize-Progressbar. I have a pull request to update the gem but I'm not sure if the author is really supporting it anymore. I've created a pull request for that here: https://github.com/kitamomonga/Mechanize-ProgressBar/pull/4
