### PR TITLE
Sanitize non-NTFS characters in episodes' titles

### DIFF
--- a/lib/ruby_tapas_downloader/downloadables/episode.rb
+++ b/lib/ruby_tapas_downloader/downloadables/episode.rb
@@ -22,7 +22,7 @@ class RubyTapasDownloader::Downloadables::Episode <
   #
   # @return [String] the sanitized title.
   def sanitized_title
-    @sanitized_title ||= title.downcase.gsub(/[^\w<>#?!$]+/, '-')
+    @sanitized_title ||= title.downcase.gsub(/[\s\x00\/\\:\*\?\"<>\|]+/, '-')
   end
 
   # Download the Episode.

--- a/spec/ruby_tapas_downloader/downloadables/episode_spec.rb
+++ b/spec/ruby_tapas_downloader/downloadables/episode_spec.rb
@@ -19,7 +19,7 @@ describe RubyTapasDownloader::Downloadables::Episode do
 
   let(:title)           { '999 Some: Ruby Tapas Episode with <<' }
   let(:link)            { 'http://example.com' }
-  let(:sanitized_title) { '999-some-ruby-tapas-episode-with-<<' }
+  let(:sanitized_title) { '999-some-ruby-tapas-episode-with-' }
 
   specify('#title') { expect(episode.title).to eq(title) }
   specify('#link') { expect(episode.link).to eq(link) }


### PR DESCRIPTION
Now sanitize_title method replaces all characters invalid in NTFS. So Windows users will be happy.