### PR TITLE
Docs: Explain download_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Usage
 $ ruby-tapas-downloader download -e <email> -p <password> -d <download_path>
 ```
 
+`download_path` is the name of a directory, relative to `pwd`. The directory 
+will be created, and episodes saved there.
+
 If you prefer, you can pre-configure, in that way you don't need to authenticate
 every download.
 


### PR DESCRIPTION
May be obvious to some people, wasn't obvious to me. I thought I was supposed to give a URL. Hope it helps.

Thanks for the useful tool!
